### PR TITLE
feat: Create Graduate page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import { createContext } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./App.css";
 import Home from "./pages/Home";
+import Graduate from "./pages/member/Graduate";
 
 export const ArticleContext = createContext();
 
@@ -11,6 +12,7 @@ const App = () => {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/graduate" element={<Graduate />} />
         </Routes>
       </BrowserRouter>
     </ArticleContext.Provider>

--- a/src/pages/member/Graduate.js
+++ b/src/pages/member/Graduate.js
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from "react";
+import {
+  Stack,
+  Button,
+  Grid,
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  CardMedia,
+} from "@mui/material";
+import {
+  createTheme,
+  ThemeProvider,
+  experimental_sx as sx,
+} from "@mui/material/styles";
+import Header from "../../components/Header";
+import SubHeader from "../../components/SubHeader";
+import Footer from "../../components/Footer";
+
+/**
+ *@author LimEunSang, dmstkd2905@naver.com
+ *@date 2022-05-02
+ *@description 년도(올해, 작년)를 선택하여
+ *             해당하는 년도에 입학한 대학원생을 랜더링
+ */
+
+const ButtonTheme = createTheme({
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        outlinedSizeLarge: sx({
+          color: "black",
+          borderColor: "black",
+          borderRadius: 0,
+          px: 6,
+          py: 1,
+        }),
+      },
+    },
+  },
+});
+
+const dummys = [
+  { name: "이름1", content: "분야 및 상세 설명1", year: 2022 },
+  { name: "이름2", content: "분야 및 상세 설명2", year: 2022 },
+  { name: "이름3", content: "분야 및 상세 설명3", year: 2022 },
+  { name: "이름4", content: "분야 및 상세 설명4", year: 2021 },
+  { name: "이름5", content: "분야 및 상세 설명5", year: 2021 },
+];
+
+const getStringYear = (date) => {
+  let year = date.getFullYear();
+  return `${year}`;
+};
+
+const Graduate = () => {
+  const [selectedYear, SetSelectedYear] = useState("all");
+
+  let year = getStringYear(new Date());
+
+  return (
+    <>
+      <Header />
+
+      <SubHeader main="구성원" sub="대학원생" />
+
+      {/* 년도 선택 버튼 그룹 */}
+      <ThemeProvider theme={ButtonTheme}>
+        <Stack
+          spacing={2}
+          direction="row"
+          justifyContent="center"
+          sx={{ my: 6, display: "flex" }}
+        >
+          <Button
+            variant="outlined"
+            size="large"
+            onClick={() => SetSelectedYear("all")}
+          >
+            ALL
+          </Button>
+          <Button
+            variant="outlined"
+            size="large"
+            onClick={() => SetSelectedYear(parseInt(year))}
+          >
+            {year}
+          </Button>
+          <Button
+            variant="outlined"
+            size="large"
+            onClick={() => SetSelectedYear(parseInt(year - 1))}
+          >
+            {year - 1}
+          </Button>
+        </Stack>
+      </ThemeProvider>
+
+      {/* 대학원생 정보 */}
+      <Container sx={{ width: "80%", my: 6 }}>
+        <Grid container spacing={2}>
+          {dummys
+            .filter((dummy) => {
+              if (selectedYear === "all" || selectedYear === dummy.year)
+                return true;
+              return false;
+            })
+            .map((dummy) => (
+              <Grid item key={dummy} sm={12} md={6} sx={{ display: "flex" }}>
+                <Card
+                  sx={{
+                    display: "flex",
+                    boxShadow: 0,
+                    border: 1,
+                    borderRadius: 0,
+                  }}
+                >
+                  <CardMedia
+                    component="img"
+                    sx={{ width: "20%", p: 2 }}
+                    image="https://source.unsplash.com/random"
+                    alt="random"
+                  />
+                  <CardContent
+                    sx={{
+                      flexDirection: "column",
+                      width: "100%",
+                    }}
+                  >
+                    <Typography
+                      variant="h6"
+                      sx={{
+                        border: "1px solid",
+                        height: "30%",
+                        display: "flex",
+                        alignItems: "center",
+                        pl: 1,
+                      }}
+                      gutterBottom
+                    >
+                      {dummy.name}
+                    </Typography>
+                    <Typography
+                      variant="body1"
+                      // 사진 크기에 따라 height percent 값을 수정해줘야함.
+                      sx={{ border: "1px solid", height: "58%", p: 1 }}
+                    >
+                      {dummy.content}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+        </Grid>
+      </Container>
+
+      <Footer />
+    </>
+  );
+};
+
+export default Graduate;

--- a/src/pages/member/Graduate.js
+++ b/src/pages/member/Graduate.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   Stack,
   Button,
@@ -36,6 +36,11 @@ const ButtonTheme = createTheme({
           px: 6,
           py: 1,
         }),
+        root: {
+          ":hover": {
+            border: "0",
+          },
+        },
       },
     },
   },
@@ -76,6 +81,7 @@ const Graduate = () => {
           <Button
             variant="outlined"
             size="large"
+            sx={{ border: "0", boxShadow: "5" }}
             onClick={() => SetSelectedYear("all")}
           >
             ALL
@@ -83,6 +89,7 @@ const Graduate = () => {
           <Button
             variant="outlined"
             size="large"
+            sx={{ border: "0", boxShadow: "5" }}
             onClick={() => SetSelectedYear(parseInt(year))}
           >
             {year}
@@ -90,6 +97,7 @@ const Graduate = () => {
           <Button
             variant="outlined"
             size="large"
+            sx={{ border: "0", boxShadow: "5" }}
             onClick={() => SetSelectedYear(parseInt(year - 1))}
           >
             {year - 1}
@@ -111,8 +119,7 @@ const Graduate = () => {
                 <Card
                   sx={{
                     display: "flex",
-                    boxShadow: 0,
-                    border: 1,
+                    boxShadow: "5",
                     borderRadius: 0,
                   }}
                 >
@@ -131,7 +138,7 @@ const Graduate = () => {
                     <Typography
                       variant="h6"
                       sx={{
-                        border: "1px solid",
+                        boxShadow: "3",
                         height: "30%",
                         display: "flex",
                         alignItems: "center",
@@ -144,7 +151,11 @@ const Graduate = () => {
                     <Typography
                       variant="body1"
                       // 사진 크기에 따라 height percent 값을 수정해줘야함.
-                      sx={{ border: "1px solid", height: "58%", p: 1 }}
+                      sx={{
+                        height: "58%",
+                        p: 1,
+                        boxShadow: "3",
+                      }}
                     >
                       {dummy.content}
                     </Typography>


### PR DESCRIPTION
구성원 -> 대학원생 페이지를 구현했습니다.
데이터베이스에 연동할 대학원생 정보는 dummydate로 임시 저장했습니다.
현재 날짜의 년도를 받아와 랜더링 했습니다. 년도가 바뀔때마다 자동
갱신됩니다.
선택된 년도에 해당한 대학원생만 랜더링하기 위해 filter 함수를 적용했습니다.
저장될 사진의 크기를 확정할 수 없어 높이를 맞추기 위해 임시 코드
작성했습니다. 후에 수정이 필요합니다.

![image](https://user-images.githubusercontent.com/86942472/166414547-cdfe873f-8ad4-4d1c-b766-0412ba5fa2aa.png)

이슈 번호 : 
#9 #10