### PR TITLE
feat: Add navigate function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,21 +24,35 @@ const App = () => {
     <ArticleContext.Provider>
       <BrowserRouter>
         <Routes>
+          {/* 홈 */}
           <Route path="/" element={<Home />} />
-          <Route path="/graduate" element={<Graduate />} />
-          <Route path="/thesis" element={<Thesis />} />
-          <Route path="/committee" element={<Committee />} />
-          <Route path="/location" element={<Location />} />
-          <Route path="/history" element={<History />} />
+
+          {/* 소개 */}
           <Route path="/introduction" element={<Introduction />} />
-          <Route path="/article" element={<Article />} />
-          <Route path="/announcement" element={<Announcement />} />
-          <Route path="/apply" element={<Apply />} />
           <Route path="/organizationchart" element={<OrganizationChart />} />
-          <Route path="/researcher" element={<Researcher />} />
-          <Route path="/undergraduate" element={<Undergraduates />} />
-          <Route path="/infochannel" element={<InfoChannel />} />
+          <Route path="/history" element={<History />} />
+          <Route path="/location" element={<Location />} />
+
+          {/* 연구 */}
+          {/* AI연구분야 페이지 추가 예정 */}
+          {/* 연구프로젝트 페이지 추가 예정 */}
+          <Route path="/thesis" element={<Thesis />} />
           <Route path="/demo" element={<Demo />} />
+
+          {/* 구성원 */}
+          {/* 참여교수 페이지 추가 예정 */}
+          <Route path="/committee" element={<Committee />} />
+          <Route path="/graduate" element={<Graduate />} />
+          <Route path="/undergraduate" element={<Undergraduates />} />
+          <Route path="/researcher" element={<Researcher />} />
+
+          {/* 소식 */}
+          <Route path="/infochannel" element={<InfoChannel />} />
+          <Route path="/announcement" element={<Announcement />} />
+          <Route path="/article" element={<Article />} />
+
+          {/* 지원하기 */}
+          <Route path="/apply" element={<Apply />} />
         </Routes>
       </BrowserRouter>
     </ArticleContext.Provider>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -37,46 +37,46 @@ const mainMenuItems = [
     key: 1,
     title: "소개",
     contents: [
-      { subkey: 6, subcontent: "연구센터소개" },
-      { subkey: 7, subcontent: "조직도" },
-      { subkey: 8, subcontent: "연혁" },
-      { subkey: 9, subcontent: "센터위치" },
+      { subkey: 6, subcontent: "연구센터소개", path: "/introduction" },
+      { subkey: 7, subcontent: "조직도", path: "/organizationchart" },
+      { subkey: 8, subcontent: "연혁", path: "/history" },
+      { subkey: 9, subcontent: "센터위치", path: "/location" },
     ],
   },
   {
     key: 2,
     title: "연구",
     contents: [
-      { subkey: 10, subcontent: "AI연구분야" },
-      { subkey: 11, subcontent: "연구프로젝트" },
-      { subkey: 12, subcontent: "연구논문" },
-      { subkey: 13, subcontent: "연구결과데모" },
+      { subkey: 10, subcontent: "AI연구분야", path: "/" },
+      { subkey: 11, subcontent: "연구프로젝트", path: "/" },
+      { subkey: 12, subcontent: "연구논문", path: "/thesis" },
+      { subkey: 13, subcontent: "연구결과데모", path: "/demo" },
     ],
   },
   {
     key: 3,
     title: "구성원",
     contents: [
-      { subkey: 14, subcontent: "참여교수" },
-      { subkey: 15, subcontent: "운영위원회" },
-      { subkey: 16, subcontent: "대학원생" },
-      { subkey: 17, subcontent: "학부 연구원생" },
-      { subkey: 18, subcontent: "연구원" },
+      { subkey: 14, subcontent: "참여교수", path: "/" },
+      { subkey: 15, subcontent: "운영위원회", path: "/committee" },
+      { subkey: 16, subcontent: "대학원생", path: "/graduate" },
+      { subkey: 17, subcontent: "학부 연구원생", path: "/undergraduate" },
+      { subkey: 18, subcontent: "연구원", path: "/researcher" },
     ],
   },
   {
     key: 4,
     title: "소식",
     contents: [
-      { subkey: 19, subcontent: "소식통" },
-      { subkey: 20, subcontent: "공지사항" },
-      { subkey: 21, subcontent: "언론보도" },
+      { subkey: 19, subcontent: "소식통", path: "/infochannel" },
+      { subkey: 20, subcontent: "공지사항", path: "/announcement" },
+      { subkey: 21, subcontent: "언론보도", path: "/article" },
     ],
   },
   {
     key: 5,
     title: "지원하기",
-    contents: [{ subkey: 22, subcontent: "지원하기" }],
+    contents: [{ subkey: 22, subcontent: "지원하기", path: "/apply" }],
   },
 ];
 
@@ -344,10 +344,11 @@ const Header = () => {
                           disablePadding
                           sx={{ bgcolor: "white" }}
                         >
-                          {contents.map(({ subkey, subcontent }) => (
+                          {contents.map(({ subkey, subcontent, path }) => (
                             <ListItemButton
                               sx={{ pl: 4, color: "black" }}
                               key={subkey}
+                              onClick={() => navigate(`${path}`)}
                             >
                               <ListItemText primary={subcontent} />
                             </ListItemButton>
@@ -379,15 +380,18 @@ const Header = () => {
           <Grid item xs={1} />
           <Grid container xs={10}>
             <Grid container xs={8}>
-              {mainMenuItems.map(({ contents }) => (
+              {mainMenuItems.map((mainMenuItem) => (
                 <>
                   <Divider orientation="vertical" />
                   <Grid item xs>
                     <Stack sx={{ height: "100%" }}>
-                      {contents.map(({ subcontent }) => (
-                        <Button sx={{ height: "20%", color: "black" }}>
+                      {mainMenuItem.contents.map((content) => (
+                        <Button
+                          sx={{ height: "20%", color: "black" }}
+                          onClick={() => navigate(content.path)}
+                        >
                           <Typography variant="subtitle2">
-                            {subcontent}
+                            {content.subcontent}
                           </Typography>
                         </Button>
                       ))}


### PR DESCRIPTION
- 해더에 각 페이지 버튼을 클릭했을 때 페이지가 이동하게 navigate를 구현했습니다. 그러기 위해서 Header.js 파일 내에 있는 mainMenuItems 객체에 path 속성을 추가했습니다. 아직 구현이 안 된 페이지의 경우 경로를 비워놨으니 페이지 구현한 branch merge 시 path 속성의 내용을 채워주세요.
<img width="604" alt="image" src="https://user-images.githubusercontent.com/86942472/170864889-d793fc2b-5370-40e8-9640-aa06c9ef2a0f.png">


- Header.js 파일의 347줄(사이드 메뉴)에서와 같이 map 함수를 쓸 때 객체의 특정 맴버만 골라서 참조하면 351줄 같이 백틱을 써야 합니다.
<img width="614" alt="image" src="https://user-images.githubusercontent.com/86942472/170864217-9cbc58c7-b85d-43d3-bc54-9f6f2ce7f04e.png">
하지만 388줄(collapase 메뉴)에서와 같이 객체 자체를 참조하면 391줄 같이 백틱 없이 참조할 수 있습니다.
<img width="531" alt="image" src="https://user-images.githubusercontent.com/86942472/170864248-488e1577-bf1b-4467-8a5f-35234788473f.png">
공부 목적으로 두 가지 방식의 코드 내용을 모두 보여드리고자 우선 이렇게 구현했습니다. <br>

- App.js 파일의 Routes 부분을 보기 좋게 분류했습니다.
<img width="604" alt="image" src="https://user-images.githubusercontent.com/86942472/170864601-dc7563f2-0ba9-410e-b6b5-31733592a9f6.png">
구현이 완료된 페이지는 37, 38, 43줄에 Route 태그를 정의해주세요
