### PR TITLE
feat: apply mockAPI in member page

### DIFF
--- a/src/components/MemberPost.js
+++ b/src/components/MemberPost.js
@@ -3,7 +3,7 @@ import { Grid, Typography, Card, CardContent, CardMedia } from "@mui/material";
 
 /**
  *@author LimEunSang, dmstkd2905@naver.com
- *@date 2022-05-07
+ *@date 2022-07-17
  *@description name, content, image 등이 포함된 게시글 컴포넌트
  */
 
@@ -15,40 +15,69 @@ const MemberPost = ({ post }) => {
           display: "flex",
           boxShadow: "5",
           borderRadius: 0,
+          width: "100vw",
         }}
       >
+        {/* 사진 */}
         <CardMedia
           component="img"
-          sx={{ width: "20%", p: 2 }}
+          sx={{ width: 200, p: 2 }}
           image={post.image}
           alt="random"
         />
+
+        {/* 내용 */}
         <CardContent
           sx={{
             flexDirection: "column",
             width: "100%",
+            display: "flex",
+            justifyContent: "center",
           }}
         >
+          {/* 이름 */}
           <Typography
             variant="h6"
             sx={{
-              height: "30%",
               display: "flex",
-              alignItems: "center",
-              pl: 1,
+              p: 1,
+              fontSize: "28px",
             }}
-            gutterBottom
           >
             {post.name}
           </Typography>
+
+          {/* 전공 */}
           <Typography
             variant="body1"
             sx={{
               p: 1,
             }}
           >
-            {post.content}
+            {post.major}
           </Typography>
+
+          {/* 연구실 위치 */}
+          <Typography
+            variant="body1"
+            sx={{
+              p: 1,
+            }}
+          >
+            {post.location}
+          </Typography>
+
+          {/* 입학 년도 */}
+          {post.admission && (
+            <Typography
+              variant="body1"
+              sx={{
+                p: 1,
+              }}
+            >
+              {post.admission}
+            </Typography>
+          )}
         </CardContent>
       </Card>
     </Grid>

--- a/src/pages/member/Graduate.js
+++ b/src/pages/member/Graduate.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import { Stack, Button, Grid, Container } from "@mui/material";
 import {
   createTheme,
@@ -12,7 +13,7 @@ import MemberPost from "../../components/MemberPost";
 
 /**
  *@author LimEunSang, dmstkd2905@naver.com
- *@date 2022-05-02
+ *@date 2022-07-17
  *@description 년도(올해, 작년)를 선택하여
  *             해당하는 년도에 입학한 대학원생을 랜더링
  */
@@ -38,39 +39,6 @@ const ButtonTheme = createTheme({
   },
 });
 
-const graduates = [
-  {
-    name: "이름1",
-    content: "분야 및 상세 설명1",
-    year: 2022,
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름2",
-    content: "분야 및 상세 설명2",
-    year: 2022,
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름3",
-    content: "분야 및 상세 설명3",
-    year: 2022,
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름4",
-    content: "분야 및 상세 설명4",
-    year: 2021,
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름5",
-    content: "분야 및 상세 설명5",
-    year: 2021,
-    image: "https://source.unsplash.com/random",
-  },
-];
-
 const getStringYear = (date) => {
   let year = date.getFullYear();
   return `${year}`;
@@ -78,15 +46,24 @@ const getStringYear = (date) => {
 
 const Graduate = () => {
   const [selectedYear, SetSelectedYear] = useState("all");
+  const [graduatesData, setGraduatesData] = useState({ graduate: [] });
 
   let year = getStringYear(new Date());
+
+  useEffect(() => {
+    axios
+      .get(
+        "https://8d020d2f-f787-45d5-88de-64d4ae1c030c.mock.pstmn.io/graduates"
+      )
+      .then((response) => {
+        setGraduatesData(response.data);
+      });
+  }, []);
 
   return (
     <>
       <Header />
-
       <SubHeader main="구성원" sub="대학원생" />
-
       {/* 년도 선택 버튼 그룹 */}
       <ThemeProvider theme={ButtonTheme}>
         <Stack
@@ -118,22 +95,20 @@ const Graduate = () => {
           </Button>
         </Stack>
       </ThemeProvider>
-
       {/* 대학원생 정보 */}
       <Container sx={{ width: "80%", my: 6 }}>
-        <Grid container spacing={2}>
-          {graduates
+        <Grid container spacing={6}>
+          {graduatesData.graduate
             .filter((graduate) => {
-              if (selectedYear === "all" || selectedYear === graduate.year)
+              if (selectedYear === "all" || selectedYear === graduate.admission)
                 return true;
               return false;
             })
             .map((graduate) => (
-              <MemberPost post={graduate} />
+              <MemberPost post={graduate} key={graduate.id} />
             ))}
         </Grid>
       </Container>
-
       <Footer />
     </>
   );

--- a/src/pages/member/Researcher.js
+++ b/src/pages/member/Researcher.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import { Grid, Container } from "@mui/material";
 import Header from "../../components/Header";
 import SubHeader from "../../components/SubHeader";
@@ -7,40 +8,23 @@ import MemberPost from "../../components/MemberPost";
 
 /**
  *@author LimEunSang, dmstkd2905@naver.com
- *@date 2022-05-09
+ *@date 2022-07-17
  *@description 연구원들의 정보를 게시글 형식으로 렌더링하는 페이지
- *             데이터베이스와 연동할 연구원 객체 정보는 임시로 dummydata를 사용
  */
 
-const researchs = [
-  {
-    name: "이름1",
-    content: "분야 및 상세 설명1",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름2",
-    content: "분야 및 상세 설명2",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름3",
-    content: "분야 및 상세 설명3",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름4",
-    content: "분야 및 상세 설명4",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름5",
-    content: "분야 및 상세 설명5",
-    image: "https://source.unsplash.com/random",
-  },
-];
-
 const Researcher = () => {
+  const [researchersData, setResearchersData] = useState({ researcher: [] });
+
+  useEffect(() => {
+    axios
+      .get(
+        "https://8d020d2f-f787-45d5-88de-64d4ae1c030c.mock.pstmn.io/researchers"
+      )
+      .then((response) => {
+        setResearchersData(response.data);
+      });
+  }, []);
+
   return (
     <>
       <Header />
@@ -49,9 +33,9 @@ const Researcher = () => {
 
       {/* 연구원 정보 */}
       <Container sx={{ width: "80%", my: 6 }}>
-        <Grid container spacing={2}>
-          {researchs.map((research) => (
-            <MemberPost post={research} />
+        <Grid container spacing={6}>
+          {researchersData.researcher.map((researcher) => (
+            <MemberPost post={researcher} key={researcher.id} />
           ))}
         </Grid>
       </Container>

--- a/src/pages/member/Undergraduate.js
+++ b/src/pages/member/Undergraduate.js
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import { Grid, Container } from "@mui/material";
 import Header from "../../components/Header";
 import SubHeader from "../../components/SubHeader";
@@ -6,40 +8,25 @@ import MemberPost from "../../components/MemberPost";
 
 /**
  *@author LimEunSang, dmstkd2905@naver.com
- *@date 2022-05-09
+ *@date 2022-07-17
  *@description 학부연구원생들의 정보를 게시글 형식으로 렌더링하는 페이지
- *             데이터베이스와 연동할 학부연구원생 객체 정보는 임시로 dummydata를 사용
  */
 
-const undergraduates = [
-  {
-    name: "이름1",
-    content: "분야 및 상세 설명1",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름2",
-    content: "분야 및 상세 설명2",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름3",
-    content: "분야 및 상세 설명3",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름4",
-    content: "분야 및 상세 설명4",
-    image: "https://source.unsplash.com/random",
-  },
-  {
-    name: "이름5",
-    content: "분야 및 상세 설명5",
-    image: "https://source.unsplash.com/random",
-  },
-];
-
 const Undergraduates = () => {
+  const [undergraduatesData, setUndergraduatesData] = useState({
+    undergraduate: [],
+  });
+
+  useEffect(() => {
+    axios
+      .get(
+        "https://8d020d2f-f787-45d5-88de-64d4ae1c030c.mock.pstmn.io/undergraduates"
+      )
+      .then((response) => {
+        setUndergraduatesData(response.data);
+      });
+  }, []);
+
   return (
     <>
       <Header />
@@ -48,9 +35,9 @@ const Undergraduates = () => {
 
       {/* 연구원 정보 */}
       <Container sx={{ width: "80%", my: 6 }}>
-        <Grid container spacing={2}>
-          {undergraduates.map((undergraduate) => (
-            <MemberPost post={undergraduate} />
+        <Grid container spacing={6}>
+          {undergraduatesData.undergraduate.map((undergraduate) => (
+            <MemberPost post={undergraduate} key={undergraduate.id} />
           ))}
         </Grid>
       </Container>


### PR DESCRIPTION
'대학원생, 학부 연구원생, 연구원' 페이지에서 수정된 API의 형식으로 UI를 수정하고 mockAPI를 적용했습니다.

- 멤버마다 가지고 있는 정보가 다릅니다. 예를 들어 대학원생에게는 연구원에게 없는 입학년도인 'admission' 속성을 가지고 있습니다. 이 다른 속성들을 동일한 컴포넌트로 출력하기 위해 정보를 가지고 있을 때만 출력하도록 코드를 작성했습니다.
```js
{/* 입학 년도 */}
{post.admission && (
    <Typography
        variant="body1"
        sx={{
            p: 1,
        }}
    >
    {post.admission}
    </Typography>
)}
```

- 스크린샷입니다.
![image](https://user-images.githubusercontent.com/86942472/179399231-1c61d414-0851-42c4-b393-0e3c6763b80b.png)
![image](https://user-images.githubusercontent.com/86942472/179399235-0c66d5d6-9676-467a-a949-4806aaa6282d.png)
![image](https://user-images.githubusercontent.com/86942472/179399240-99bdf7d3-d5b4-4aa6-87b1-850f73e02c9f.png)


