### PR TITLE
feat: Add Admin Researcher Page

### DIFF
--- a/src/admin/AdminMain.js
+++ b/src/admin/AdminMain.js
@@ -35,8 +35,8 @@ const adminHeaderItems = [
     key: 1,
     title: "구성원",
     contents: [
-      { subkey: 4, subcontent: "교수", path: "professor" },
-      { subkey: 5, subcontent: "연구원", path: "researcher" },
+      { subkey: 4, subcontent: "교수", path: "members/professor" },
+      { subkey: 5, subcontent: "연구원", path: "members/researcher" },
       { subkey: 6, subcontent: "석사", path: "graduate" },
       { subkey: 7, subcontent: "학사", path: "undergraduate" },
       { subkey: 8, subcontent: "운영위원회", path: "committee" },
@@ -193,8 +193,8 @@ const AdminMain = () => {
           {/* MainContent */}
           <Routes>
             {/* Member */}
-            <Route path="professor" element={<Professor />} />
-            <Route path="researcher" element={<Researcher />} />
+            <Route path="members/professor" element={<Professor />} />
+            <Route path="members/researcher" element={<Researcher />} />
             <Route path="committee" element={<Committee />} />
             <Route path="graduate" element={<Graduate />} />
             <Route path="undergraduate" element={<Undergraduate />} />

--- a/src/admin/components/member/Professor.js
+++ b/src/admin/components/member/Professor.js
@@ -8,43 +8,8 @@ import {
 
 import { Button, Pagination, TextField, Box } from "@mui/material";
 
-const dummyRows = [
-  {
-    id: 1,
-    name: "나승훈",
-    position: "교수",
-    major: "인공지능",
-    email: "nsh@gmail.com",
-  },
-  {
-    id: 2,
-    name: "나훈승",
-    position: "교수",
-    major: "인공지능",
-    email: "nhs@gmail.com",
-  },
-  {
-    id: 3,
-    name: "승훈나",
-    position: "교수",
-    major: "인공지능",
-    email: "shn@gmail.com",
-  },
-  {
-    id: 4,
-    name: "승나훈",
-    position: "교수",
-    major: "인공지능",
-    email: "snh@gmail.com",
-  },
-  {
-    id: 5,
-    name: "훈승나",
-    position: "교수",
-    major: "인공지능",
-    email: "hsn@gmail.com",
-  },
-];
+import { useState, useEffect } from "react";
+import axios from "axios";
 
 const dummycolumns = [
   {
@@ -73,6 +38,9 @@ const dummycolumns = [
     headerAlign: "center",
     disableColumnMenu: true,
     align: "center",
+    valueFormatter: (params) => {
+      return "교수";
+    },
   },
   {
     field: "major",
@@ -120,6 +88,18 @@ const CustomPagination = () => {
  */
 
 const Professor = () => {
+  const [data, setData] = useState({ position: "", members: [] });
+
+  useEffect(() => {
+    axios({
+      method: "get",
+      url: "https://4051bb99-f161-4f6e-8c33-dd389141803f.mock.pstmn.io/AdminProfessor",
+      responseType: "json",
+    }).then((response) => {
+      setData(response.data);
+    });
+  }, []);
+
   return (
     <div
       style={{
@@ -146,7 +126,7 @@ const Professor = () => {
         </Button>
       </Box>
       <DataGrid
-        rows={dummyRows}
+        rows={data.members}
         columns={dummycolumns}
         pageSize={15}
         sortingOrder={["desc", "asc"]}

--- a/src/admin/components/member/Researcher.js
+++ b/src/admin/components/member/Researcher.js
@@ -1,8 +1,144 @@
-const Researcher = () => {
+import {
+  DataGrid,
+  gridPageCountSelector,
+  gridPageSelector,
+  useGridApiContext,
+  useGridSelector,
+} from "@mui/x-data-grid";
+
+import { Button, Pagination, TextField, Box } from "@mui/material";
+
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+const dummycolumns = [
+  {
+    field: "id",
+    headerName: "ID",
+    flex: 1,
+    disableColumnMenu: true,
+    headerAlign: "center",
+    sortable: true,
+    align: "center",
+  },
+  {
+    field: "name",
+    headerName: "이름",
+    flex: 3,
+    disableColumnMenu: true,
+    headerAlign: "center",
+    sortable: true,
+    align: "center",
+  },
+  {
+    field: "position",
+    headerName: "직책",
+    flex: 3,
+    sortable: true,
+    headerAlign: "center",
+    disableColumnMenu: true,
+    align: "center",
+    valueFormatter: (params) => {
+      return "연구원";
+    },
+  },
+  {
+    field: "major",
+    headerName: "전공",
+    flex: 3,
+    sortable: true,
+    headerAlign: "center",
+    disableColumnMenu: true,
+    align: "center",
+  },
+  {
+    field: "email",
+    headerName: "이메일",
+    sortable: true,
+    flex: 3,
+    headerAlign: "center",
+    disableColumnMenu: true,
+    align: "center",
+  },
+];
+
+// 추후 삭제 예정 - virtualization로 바꿀것
+const CustomPagination = () => {
+  const apiRef = useGridApiContext();
+  const page = useGridSelector(apiRef, gridPageSelector);
+  const pageCount = useGridSelector(apiRef, gridPageCountSelector);
+
   return (
-    <div>
-      연구원페이지 입니다.연구원페이지 입니다.연구원페이지 입니다.연구원페이지
-      입니다.연구원페이지 입니다.
+    <Pagination
+      color="primary"
+      count={pageCount}
+      page={page + 1}
+      onChange={(event, value) => apiRef.current.setPage(value - 1)}
+      showLastButton
+      showFirstButton
+    />
+  );
+};
+
+/**
+ *@author Suin-Jeong suin8@jbnu.ac.kr
+ *@date 2022-07-25
+ *@description Admin Researcher 페이지
+ *             DataGrid 이용
+ */
+
+const Researcher = () => {
+  const [data, setData] = useState({ position: "", members: [] });
+
+  useEffect(() => {
+    axios({
+      method: "get",
+      url: "https://4051bb99-f161-4f6e-8c33-dd389141803f.mock.pstmn.io/AdminResearcher",
+      responseType: "json",
+    }).then((response) => {
+      setData(response.data);
+    });
+  }, []);
+
+  return (
+    <div
+      style={{
+        paddingTop: "3%",
+        paddingBottom: "3%",
+        paddingLeft: "7.5%",
+        paddingRight: "7.5%",
+      }}
+    >
+      <Box sx={{ display: "flex", mb: "2%", justifyContent: "flex-end" }}>
+        <TextField
+          id="outlined-basic"
+          label="Search"
+          variant="outlined"
+          sx={{
+            width: "20%",
+            display: "flex",
+            justifyContent: "right",
+            mr: "3%",
+          }}
+        />
+        <Button variant="contained" size="large">
+          등록하기
+        </Button>
+      </Box>
+      <DataGrid
+        rows={data.members}
+        columns={dummycolumns}
+        pageSize={15}
+        sortingOrder={["desc", "asc"]}
+        autoHeight
+        autoPageSize
+        hideFooterSelectedRowCount
+        components={{
+          Pagination: CustomPagination,
+        }}
+        sx={{ cursor: "pointer" }}
+        //onRowClick={() => navigate(`/professor/${dummyRows.id}`)} // 수정 필요!!!
+      />
     </div>
   );
 };


### PR DESCRIPTION
연구원 페이지 추가하였습니다.
Admin Main약간 수정했습니다.
- Admin Professor Page 추가하였습니다.
- API시나리오 대로 URL수정하였습니다.
- AdminProfessor, AdminResearcher Mock API적용하였습니다.
![image](https://user-images.githubusercontent.com/90179555/180712989-86ed1dfd-54b6-4e81-9714-00784c213e97.png)


[#79]
+) API시나리오 각 직책별 멤버 전체 조회를 보면 직책이 객체별로 존재X
따라서 ValueFormatter를 이용하여 우선 교수, 연구원으로 일괄 채워넣음
추후 UI나 API변경 시 따라서  변경필요